### PR TITLE
Added an endpoint to apikeys to check if a secret key exists for a given project

### DIFF
--- a/src/api-keys/api-keys.controller.ts
+++ b/src/api-keys/api-keys.controller.ts
@@ -9,7 +9,7 @@ export class ApiKeysController {
   constructor(private readonly apiKeysService: ApiKeysService) { }
 
   /**
-   * Creates a API key secret for the given project
+   * Creates an API key secret for the given project
    * @param projectId
    * @returns the generated API key secret or error if secret already exists
    */
@@ -17,6 +17,17 @@ export class ApiKeysController {
   @Post('/secret/:projectId')
   createSecret(@Param('projectId') projectId: string) {
     return this.apiKeysService.createSecretKey(projectId);
+  }
+
+  /**
+   * Checks if an API key secret for the given project exists
+   * @param projectId
+   * @returns the generated API key secret or error if secret already exists
+   */
+  @UseGuards(JwtAuthGuard, IsProjectOwnerGuard)
+  @Get('/secret/:projectId')
+  checkIfSecretExists(@Param('projectId') projectId: string) {
+    return this.apiKeysService.checkIfSecretExists(projectId);
   }
 
   /**

--- a/src/api-keys/api-keys.service.ts
+++ b/src/api-keys/api-keys.service.ts
@@ -13,33 +13,6 @@ export class ApiKeysService {
     private apiKeyModel: Model<ApiKey>,
   ) { }
 
-  async createKeys(projectId: string) {
-    const publicKey = `pk_${await this.generateRandomToken()}`;
-    const secretKey = `sk_${await this.generateRandomToken()}`;
-    const saltRounds = await bcrypt.genSalt();
-    const secretHash = await bcrypt.hash(secretKey, saltRounds);
-    const result = await this.apiKeyModel.findOneAndUpdate(
-      { projectId: projectId },
-      {
-        publicKey: publicKey,
-        secretHash: secretHash,
-      },
-      { upsert: true, new: true },
-    );
-
-    if (result) {
-      return {
-        publicKey: publicKey,
-        secretKey: secretKey,
-      };
-    }
-
-    throw new HttpException(
-      'Internal Server Error',
-      HttpStatus.INTERNAL_SERVER_ERROR,
-    );
-  }
-
   async createPublicKey(projectId: string) {
     const projectKeys = await this.apiKeyModel.findOne({
       projectId: projectId,
@@ -153,6 +126,17 @@ export class ApiKeysService {
         secretKey: newSecretKey,
       };
     }
+  }
+
+  async checkIfSecretExists(projectId: string): Promise<Boolean> {
+
+    const projectApiKeys = await this.apiKeyModel.findOne({ projectId: projectId });
+
+    if (projectApiKeys?.secretHash) {
+      return true;
+    }
+
+    return false;
   }
 
   private async generateRandomToken(): Promise<string> {


### PR DESCRIPTION
This endpoint will be used by the client to check if a secret API key was already generated for a given project.

Also removed the 'createKeys' function in ApiKeysService as it is not in use