### PR TITLE
Changed the guard for wallet and fuseswap api to check only public api key

### DIFF
--- a/apps/charge-api-service/src/api-keys/guards/is-valid-public-api-key.guard.ts
+++ b/apps/charge-api-service/src/api-keys/guards/is-valid-public-api-key.guard.ts
@@ -1,0 +1,19 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
+import { ApiKeysService } from 'apps/charge-api-service/src/api-keys/api-keys.service'
+import { isEmpty } from 'lodash'
+
+@Injectable()
+export class IsValidPublicApiKeyGuard implements CanActivate {
+  constructor (private apiKeysService: ApiKeysService) { }
+
+  async canActivate (context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest()
+    const { query }: { query: { apiKey: string } } = request
+    const projectApiKey = await this.apiKeysService.findOne({ publicKey: query?.apiKey, isTest: false })
+
+    if (!isEmpty(projectApiKey)) {
+      return true
+    }
+    return false
+  }
+}

--- a/apps/charge-api-service/src/legacy-api/legacy-fuseswap-api/legacy-fuseswap-api.controller.ts
+++ b/apps/charge-api-service/src/legacy-api/legacy-fuseswap-api/legacy-fuseswap-api.controller.ts
@@ -1,8 +1,8 @@
 import { Controller, Get, Post, UseGuards, UseInterceptors } from '@nestjs/common'
 import { LegacyApiInterceptor } from '@app/api-service/legacy-api/legacy-api.interceptor'
-import { IsValidApiKeysGuard } from '@app/api-service/api-keys/guards/is-valid-api-keys.guard'
+import { IsValidPublicApiKeyGuard } from '@app/api-service/api-keys/guards/is-valid-public-api-key.guard'
 
-@UseGuards(IsValidApiKeysGuard)
+@UseGuards(IsValidPublicApiKeyGuard)
 @UseInterceptors(LegacyApiInterceptor)
 @Controller({ path: 'v0/fuseswap/*' })
 export class LegacyFuseswapApiController {

--- a/apps/charge-api-service/src/legacy-api/legacy-wallet-api/legacy-wallet-api.controller.ts
+++ b/apps/charge-api-service/src/legacy-api/legacy-wallet-api/legacy-wallet-api.controller.ts
@@ -1,8 +1,8 @@
 import { Controller, Get, Put, Post, UseGuards, UseInterceptors } from '@nestjs/common'
 import { LegacyApiInterceptor } from '@app/api-service/legacy-api/legacy-api.interceptor'
-import { IsValidApiKeysGuard } from '@app/api-service/api-keys/guards/is-valid-api-keys.guard'
+import { IsValidPublicApiKeyGuard } from '@app/api-service/api-keys/guards/is-valid-public-api-key.guard'
 
-@UseGuards(IsValidApiKeysGuard)
+@UseGuards(IsValidPublicApiKeyGuard)
 @UseInterceptors(LegacyApiInterceptor)
 @Controller({ path: 'v0/wallets/*' })
 export class LegacyWalletApiController {


### PR DESCRIPTION
## Proposed changes

Legacy Wallet and Fuseswap APIs will require only publicKey query param which needs to be found in the DB 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
