### PR TITLE
Fixing maxBlocksToProcess issue that caused time outs with the RPC node

### DIFF
--- a/apps/charge-notifications-service/src/events-scanner/events-scanner.service.ts
+++ b/apps/charge-notifications-service/src/events-scanner/events-scanner.service.ts
@@ -38,12 +38,14 @@ export class EventsScannerService {
           ? status.blockNumber + 1
           : toBlockNumber
 
+        const maxBlocksToProcess = this.configService.get('rpcConfig').rpc.maxBlocksToProcess
+
         if (fromBlockNumber >= toBlockNumber) {
           const timeout: number = this.configService.get('rpcConfig').timeoutInterval
 
           await sleep(timeout)
-        } else if (toBlockNumber - fromBlockNumber > this.configService.get('maxBlocksToProcess')) {
-          toBlockNumber = fromBlockNumber + this.configService.get('maxBlocksToProcess')
+        } else if (toBlockNumber - fromBlockNumber > maxBlocksToProcess) {
+          toBlockNumber = fromBlockNumber + maxBlocksToProcess
         }
 
         await this.processBlocks(

--- a/apps/charge-notifications-service/src/transactions-scanner/transactions-scanner.service.ts
+++ b/apps/charge-notifications-service/src/transactions-scanner/transactions-scanner.service.ts
@@ -45,12 +45,14 @@ export class TransactionsScannerService {
           ? status.blockNumber + 1
           : toBlockNumber
 
+        const maxBlocksToProcess = this.configService.get('rpcConfig').rpc.maxBlocksToProcess
+
         if (fromBlockNumber >= toBlockNumber) {
           const timeout: number = this.configService.get('rpcConfig').timeoutInterval
 
           await sleep(timeout)
-        } else if (toBlockNumber - fromBlockNumber > this.configService.get('maxBlocksToProcess')) {
-          toBlockNumber = fromBlockNumber + this.configService.get('maxBlocksToProcess')
+        } else if (toBlockNumber - fromBlockNumber > maxBlocksToProcess) {
+          toBlockNumber = fromBlockNumber + maxBlocksToProcess
         }
 
         await this.processBlocks(


### PR DESCRIPTION
## Proposed changes

Fixing an issue where `maxBlocsToProcess` was not taken properly from the config which caused the services to try to process too many blocks and resulted in Timeout from the RPC. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
