### PR TITLE
Added support to legacy API to get tokens for ownerAddress and tokenAddress

### DIFF
--- a/apps/charge-api-service/src/legacy-api/config/configuration.ts
+++ b/apps/charge-api-service/src/legacy-api/config/configuration.ts
@@ -15,5 +15,6 @@ export default () => ({
   LegacyTradeApiController: {
     baseUrl: `${process.env.LEGACY_FUSE_TRADE_API_URL}/api/v1`,
     replaceHeaders: false
-  }
+  },
+  LegacyV1ApiUrl: `${process.env.LEGACY_FUSE_ADMIN_API_URL}/api/v1`
 })

--- a/apps/charge-api-service/src/legacy-api/legacy-admin-api/docs/Admin API.postman_collection.json
+++ b/apps/charge-api-service/src/legacy-api/legacy-admin-api/docs/Admin API.postman_collection.json
@@ -1056,6 +1056,228 @@
 									"body": ""
 								}
 							]
+						},
+						{
+							"name": "Get Tokens by Owner",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "API-SECRET",
+										"value": "{{secretKey}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/admin/tokens/owner/:ownerAddress?apiKey={{publicKey}}",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"admin",
+										"tokens",
+										"owner",
+										":ownerAddress"
+									],
+									"query": [
+										{
+											"key": "apiKey",
+											"value": "{{publicKey}}"
+										}
+									],
+									"variable": [
+										{
+											"key": "ownerAddress",
+											"value": "0xFDf589954F97b376F0794990d47948371f6824B1"
+										}
+									]
+								},
+								"description": "Get a list of tokens that belong to an `ownerAddress`"
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "API-SECRET",
+												"value": "{{secretKey}}",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/admin/tokens/owner/:ownerAddress?apiKey={{publicKey}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"admin",
+												"tokens",
+												"owner",
+												":ownerAddress"
+											],
+											"query": [
+												{
+													"key": "apiKey",
+													"value": "{{publicKey}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "ownerAddress",
+													"value": "0xFDf589954F97b376F0794990d47948371f6824B1"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Powered-By",
+											"value": "Express"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "460"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"1cc-rKcvGoYiNGFhwMthszn6wjLICJw\""
+										},
+										{
+											"key": "Date",
+											"value": "Wed, 31 Aug 2022 10:35:13 GMT"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Keep-Alive",
+											"value": "timeout=5"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"object\": \"list\",\n    \"data\": [\n        {\n            \"decimals\": 18,\n            \"spendabilityIds\": [\n                \"a\",\n                \"b\",\n                \"c\"\n            ],\n            \"_id\": \"62f2cddd78f2e5001415f396\",\n            \"address\": \"0x6F353A3A737bF3f6442BEc6246411E513285882E\",\n            \"name\": \"My Cool Token\",\n            \"symbol\": \"MCT\",\n            \"tokenURI\": \"\",\n            \"totalSupply\": \"0\",\n            \"owner\": \"0xFDf589954F97b376F0794990d47948371f6824B1\",\n            \"blockNumber\": 18521317,\n            \"tokenType\": \"expirable\",\n            \"networkType\": \"home\",\n            \"expiryTimestamp\": 1939300629,\n            \"createdAt\": \"2022-08-09T21:13:01.405Z\",\n            \"updatedAt\": \"2022-08-09T21:13:01.405Z\"\n        }\n    ]\n}"
+								}
+							]
+						},
+						{
+							"name": "Get Tokens by Address",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "API-SECRET",
+										"type": "text",
+										"value": "{{secretKey}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/admin/tokens/:tokenAddress?apiKey={{publicKey}}",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"admin",
+										"tokens",
+										":tokenAddress"
+									],
+									"query": [
+										{
+											"key": "apiKey",
+											"value": "{{publicKey}}"
+										}
+									],
+									"variable": [
+										{
+											"key": "tokenAddress",
+											"value": "0x6F353A3A737bF3f6442BEc6246411E513285882E"
+										}
+									]
+								},
+								"description": "Get a token by `tokenAddress`"
+							},
+							"response": [
+								{
+									"name": "Successful Response",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "API-SECRET",
+												"type": "text",
+												"value": "{{secretKey}}"
+											}
+										],
+										"url": {
+											"raw": "{{baseUrl}}/admin/tokens/:tokenAddress?apiKey={{publicKey}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"admin",
+												"tokens",
+												":tokenAddress"
+											],
+											"query": [
+												{
+													"key": "apiKey",
+													"value": "{{publicKey}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "tokenAddress",
+													"value": "0x6F353A3A737bF3f6442BEc6246411E513285882E"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Powered-By",
+											"value": "Express"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "442"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"1ba-2s/FS2x4fxXwfX+OgtbwpavDu10\""
+										},
+										{
+											"key": "Date",
+											"value": "Wed, 31 Aug 2022 10:35:26 GMT"
+										},
+										{
+											"key": "Connection",
+											"value": "keep-alive"
+										},
+										{
+											"key": "Keep-Alive",
+											"value": "timeout=5"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"data\": {\n        \"decimals\": 18,\n        \"spendabilityIds\": [\n            \"a\",\n            \"b\",\n            \"c\"\n        ],\n        \"_id\": \"62f2cddd78f2e5001415f396\",\n        \"address\": \"0x6F353A3A737bF3f6442BEc6246411E513285882E\",\n        \"name\": \"My Cool Token\",\n        \"symbol\": \"MCT\",\n        \"tokenURI\": \"\",\n        \"totalSupply\": \"0\",\n        \"owner\": \"0xFDf589954F97b376F0794990d47948371f6824B1\",\n        \"blockNumber\": 18521317,\n        \"tokenType\": \"expirable\",\n        \"networkType\": \"home\",\n        \"expiryTimestamp\": 1939300629,\n        \"createdAt\": \"2022-08-09T21:13:01.405Z\",\n        \"updatedAt\": \"2022-08-09T21:13:01.405Z\"\n    }\n}"
+								}
+							]
 						}
 					],
 					"description": "With Admin Tokens API, you can create a new ERC20 token, mint or burn it, and transfer it between your users' wallets"

--- a/apps/charge-api-service/src/legacy-api/legacy-admin-api/docs/admin-api.yaml
+++ b/apps/charge-api-service/src/legacy-api/legacy-admin-api/docs/admin-api.yaml
@@ -401,6 +401,107 @@ paths:
               schema:
                 type: string
               example: ''
+  /admin/tokens/owner/{ownerAddress}:
+    get:
+      tags:
+        - Admin API > Tokens
+      summary: Get Tokens by Owner
+      description: Get a list of tokens that belong to an `ownerAddress`
+      parameters:
+        - name: API-SECRET
+          in: header
+          schema:
+            type: string
+          example: '{{secretKey}}'
+        - name: apiKey
+          in: query
+          schema:
+            type: string
+          example: '{{publicKey}}'
+        - name: ownerAddress
+          in: path
+          schema:
+            type: string
+          required: true
+          example: '0xFDf589954F97b376F0794990d47948371f6824B1'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                object: list
+                data:
+                  - decimals: 18
+                    spendabilityIds:
+                      - a
+                      - b
+                      - c
+                    _id: 62f2cddd78f2e5001415f396
+                    address: '0x6F353A3A737bF3f6442BEc6246411E513285882E'
+                    name: My Cool Token
+                    symbol: MCT
+                    tokenURI: ''
+                    totalSupply: '0'
+                    owner: '0xFDf589954F97b376F0794990d47948371f6824B1'
+                    blockNumber: 18521317
+                    tokenType: expirable
+                    networkType: home
+                    expiryTimestamp: 1939300629
+                    createdAt: '2022-08-09T21:13:01.405Z'
+                    updatedAt: '2022-08-09T21:13:01.405Z'
+  /admin/tokens/{tokenAddress}:
+    get:
+      tags:
+        - Admin API > Tokens
+      summary: Get Tokens by Address
+      description: Get a token by `tokenAddress`
+      parameters:
+        - name: API-SECRET
+          in: header
+          schema:
+            type: string
+          example: '{{secretKey}}'
+        - name: apiKey
+          in: query
+          schema:
+            type: string
+          example: '{{publicKey}}'
+        - name: tokenAddress
+          in: path
+          schema:
+            type: string
+          required: true
+          example: '0x6F353A3A737bF3f6442BEc6246411E513285882E'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                data:
+                  decimals: 18
+                  spendabilityIds:
+                    - a
+                    - b
+                    - c
+                  _id: 62f2cddd78f2e5001415f396
+                  address: '0x6F353A3A737bF3f6442BEc6246411E513285882E'
+                  name: My Cool Token
+                  symbol: MCT
+                  tokenURI: ''
+                  totalSupply: '0'
+                  owner: '0xFDf589954F97b376F0794990d47948371f6824B1'
+                  blockNumber: 18521317
+                  tokenType: expirable
+                  networkType: home
+                  expiryTimestamp: 1939300629
+                  createdAt: '2022-08-09T21:13:01.405Z'
+                  updatedAt: '2022-08-09T21:13:01.405Z'
   /admin/wallets/create:
     post:
       tags:

--- a/apps/charge-api-service/src/legacy-api/legacy-admin-api/legacy-admin-api.controller.ts
+++ b/apps/charge-api-service/src/legacy-api/legacy-admin-api/legacy-admin-api.controller.ts
@@ -8,6 +8,9 @@ import { LegacyApiInterceptor } from '@app/api-service/legacy-api/legacy-api.int
 export class LegacyAdminApiController {
   @Get('/wallets/*')
   getWallets() {}
+
+  @Get('/tokens/*')
+  getTokens() {}
   
   @Get('/*')
   get () { }

--- a/apps/charge-api-service/src/legacy-api/legacy-api.interceptor.ts
+++ b/apps/charge-api-service/src/legacy-api/legacy-api.interceptor.ts
@@ -90,6 +90,14 @@ export class LegacyApiInterceptor implements NestInterceptor {
         method: 'get',
         headers
       }
+    // Handle the special case of fetching tokens for Admin API through legacy v1 Tokens API
+    } else if (ctxHandlerName === 'getTokens') {
+      const baseUrl = this.configService.get<Record<string, any>>('LegacyV1ApiUrl')
+      requestConfig = {
+        url: `${baseUrl}/tokens/${params[0]}`,
+        method: 'get',
+        headers
+      }
     } else {
       requestConfig = {
         url: `${config?.baseUrl}/${params[0]}`,


### PR DESCRIPTION
## Proposed changes

I have added support to get tokens by ownerAddress and tokenAddress through the Legacy API. This solution will only work through the API and not through the UI because the guard protect the endpoint with `publicKey` and `secretKey`. If we want to have the same functionality for the UI, we need to create another dedicated endpoint to the `Charge Accounts Service`. 

The changes include documentation files update, after approval I will update the documentation in readme. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [X] New feature (non-breaking change which adds functionality)
