### PR TITLE
Handle cases where transferring tokens to main account fails

### DIFF
--- a/apps/charge-apps-service/src/charge-api/charge-api.service.ts
+++ b/apps/charge-apps-service/src/charge-api/charge-api.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios'
-import { HttpException, Inject, Injectable, Logger } from '@nestjs/common'
+import { HttpException, HttpStatus, Inject, Injectable, Logger } from '@nestjs/common'
 import { catchError, lastValueFrom, map } from 'rxjs'
 import { isEmpty, keyBy, merge, values } from 'lodash'
 import { ConfigService } from '@nestjs/config'
@@ -110,6 +110,13 @@ export class ChargeApiService {
     jobData = await this.getUpdatedJobData(jobData)
 
     this.logger.log(JSON.stringify(jobData))
+
+    if (jobData?.data?.status === 'failed') {
+      throw new HttpException(
+        `Transfering tokens failed. Fail reason ${jobData?.data?.failReason}`,
+        HttpStatus.INTERNAL_SERVER_ERROR
+      )
+    }
 
     return jobData
   }

--- a/apps/charge-apps-service/src/payments/payments.controller.ts
+++ b/apps/charge-apps-service/src/payments/payments.controller.ts
@@ -44,7 +44,7 @@ export class PaymentsController {
 
   @Post('webhook')
   webhook (@Body() webhookEvent: WebhookEvent) {
-    this.paymentsService.handleWebhook(webhookEvent)
+    return this.paymentsService.handleWebhook(webhookEvent)
   }
 
   @UseGuards(IsValidApiKeysGuard)

--- a/apps/charge-notifications-service/src/broadcaster/broadcaster.service.ts
+++ b/apps/charge-notifications-service/src/broadcaster/broadcaster.service.ts
@@ -46,6 +46,7 @@ export class BroadcasterService {
           webhookEvent.success = true
         } catch (err) {
           if (err instanceof HttpException) {
+            this.logger.error(`Webhook returned error. Error message: ${err} \nStack: ${err?.stack}`)
             webhookEvent.responses.push(this.getResponseDetailsWithDate(err.getStatus(), err.getResponse().toString()))
             webhookEvent.numberOfTries++
             webhookEvent.retryAfter = new Date(this.getNewRetryAfterDate(webhookEvent))

--- a/libs/common/src/exceptions/all-exceptions.filter.ts
+++ b/libs/common/src/exceptions/all-exceptions.filter.ts
@@ -55,6 +55,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
       return throwError(() => ({ message: errorMessage, status: httpStatus }))
     }
 
+    response.statusCode = httpStatus
+
     httpAdapter.reply(response, responseBody, httpStatus)
   }
 }


### PR DESCRIPTION
## Proposed changes

Today there was a case where a payment link was successfully paid but for some reason, the tokens failed to be transferred to the main account. In this case, we need to return an error to the notifications service so that the webhook will be retried and in subsequent trials, it may succeed. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
