### PR TITLE
add log statements to debug duplicate actions issue

### DIFF
--- a/apps/charge-api-service/src/smart-wallets-api/smart-wallets-api-v2.controller.ts
+++ b/apps/charge-api-service/src/smart-wallets-api/smart-wallets-api-v2.controller.ts
@@ -38,8 +38,8 @@ export class SmartWalletsAPIV2Controller {
     this.logger.debug(
       'A request has been made to token-transfers:',
       JSON.stringify(tokenTransferWebhookDto),
-      `Headers: ${headers}`,
-      `Request: ${request}`
+      `headers.get('host'): ${headers.get('host')}`,
+      `headers.get('origin'): ${headers.get('origin')}`
     )
 
     await this.smartWalletsAPIService.handleTokenTransferWebhook(


### PR DESCRIPTION
- add log statements to be able to debug duplicate receive wallet actions issue
- remove unused imports
- log the JSON representation of tokenTransferWebhookDto
- log the headers and the request in token-transfers webhook endpoint
- do not log the JSON representations of header and response, log it in raw format
- log only the host and origin
