### PR TITLE
add log statements to debug duplicate actions issue

### DIFF
--- a/apps/charge-api-service/src/smart-wallets-api/smart-wallets-api-v2.controller.ts
+++ b/apps/charge-api-service/src/smart-wallets-api/smart-wallets-api-v2.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Post, Body, UseGuards, Query, Get, Logger, Headers, Req } from '@nestjs/common'
+import { Request } from 'express'
 import { IsPrdOrSbxKeyGuard } from '@app/api-service/api-keys/guards/is-production-or-sandbox-key.guard'
 import { SmartWalletsAuthDto } from '@app/smart-wallets-service/dto/smart-wallets-auth.dto'
 import { SmartWalletsAPIService } from '@app/api-service/smart-wallets-api/smart-wallets-api.service'
@@ -38,7 +39,9 @@ export class SmartWalletsAPIV2Controller {
     this.logger.debug(
       'A request has been made to token-transfers:',
       JSON.stringify(tokenTransferWebhookDto),
-      JSON.stringify(headers)
+      `request.connection.remoteAddress: ${request.connection.remoteAddress}`,
+      `request.hostname: ${request.hostname}`,
+      `rawHeaders: ${request.rawHeaders}`
     )
 
     await this.smartWalletsAPIService.handleTokenTransferWebhook(


### PR DESCRIPTION
- add log statements to be able to debug duplicate receive wallet actions issue
- remove unused imports
- log the JSON representation of tokenTransferWebhookDto
- log the headers and the request in token-transfers webhook endpoint
- do not log the JSON representations of header and response, log it in raw format
- log only the host and origin
- remove unnecessary code
- log just the headers
- log the remoteAddress and the hostname
