### PR TITLE
avoid creating duplicate webhook events

### DIFF
--- a/apps/charge-smart-wallets-service/src/data-layer/data-layer.service.ts
+++ b/apps/charge-smart-wallets-service/src/data-layer/data-layer.service.ts
@@ -89,7 +89,7 @@ export class DataLayerService {
 
     if (direction === 'incoming') {
       const receiveWalletAction =
-        this.paginatedWalletActionModel.findOne({ txHash })
+        await this.paginatedWalletActionModel.findOne({ txHash })
 
       if (receiveWalletAction) {
         this.logger.debug(


### PR DESCRIPTION
- if the webhook event already exists, do not create it
- increment numberOfTries property only in the finally block, formatting changes
- do not create a new wallet action if the wallet action already exists for the given tx
