### PR TITLE
Scale centrifugo up to 2 replicas

### DIFF
--- a/k8s/helm/production.yaml
+++ b/k8s/helm/production.yaml
@@ -158,11 +158,12 @@ centrifugo:
   enabled: true
 
   # Replicas
-  replicas: 1
+  replicas: 2
 
   # Affinity (zones)
   affinity:
     zones:
+      - a
       - b
 
   # Image


### PR DESCRIPTION
## Proposed changes

Increases default number of replicas of Centrifuo on production to 2

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
