### PR TITLE
fix: Helm - Code updates

### DIFF
--- a/k8s/helm/charts/accounts/templates/httproute.yaml
+++ b/k8s/helm/charts/accounts/templates/httproute.yaml
@@ -16,7 +16,7 @@ spec:
   rules:
     - matches:
         - path:
-            value: /
+            value: /accounts/
       filters:
         - type: ResponseHeaderModifier
           responseHeaderModifier:

--- a/k8s/helm/charts/api/templates/httproute.yaml
+++ b/k8s/helm/charts/api/templates/httproute.yaml
@@ -16,7 +16,7 @@ spec:
   rules:
     - matches:
         - path:
-            value: /
+            value: /api/
       filters:
         - type: ResponseHeaderModifier
           responseHeaderModifier:

--- a/k8s/helm/charts/centrifugo/templates/httproute.yaml
+++ b/k8s/helm/charts/centrifugo/templates/httproute.yaml
@@ -16,7 +16,9 @@ spec:
   rules:
     - matches:
         - path:
-            value: /
+            value: /api/
+        - path:
+            value: /connection/websocket
       filters:
         - type: ResponseHeaderModifier
           responseHeaderModifier:

--- a/k8s/helm/charts/skandha/templates/httproute.yaml
+++ b/k8s/helm/charts/skandha/templates/httproute.yaml
@@ -16,7 +16,9 @@ spec:
   rules:
     - matches:
         - path:
-            value: /
+            value: /122/
+        - path:
+            value: /122/
       filters:
         - type: ResponseHeaderModifier
           responseHeaderModifier:


### PR DESCRIPTION
## Proposed changes

Last time we have a lot of penetration testing requests such as `/.env`, `/wp-login/`, `robots.txt`, etc. for all exposed components. To avoid it first we need to specify the right routes for each exposed component on load balancing side. 

There is the next table:

| Component | Routes |
| ----------------- | ---------- |
| Accounts | `/accounts`, `/accounts/*` |
| API | `/api`, `/api/*` |
| Apps | `/app-store`,  `/app-store/*` |
| Centrifugo | `/api`, `/api/*`, `/connection/websocket`, `/connection/websocket/*` |
| Skandha |`/122`,  `/122/*`, `/123`, `/123/*` |

The case: the changes in `HTTPRoute` means that if the route path isn't the same as provided in the table the load balancer will return the `404` error from default GKE - owned backend service.

This configuration already have applied for `staging` environment, you can test it. Also please let me know if we need different path configuration for specific component here.

Summary:

- Fixed `HTTPRoute` resource for all exposed services

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
