### PR TITLE
Fix getWebhookAddresses not returning

### DIFF
--- a/apps/charge-accounts-service/src/operators/operators.service.ts
+++ b/apps/charge-accounts-service/src/operators/operators.service.ts
@@ -126,7 +126,7 @@ export class OperatorsService {
   async getWebhookAddresses (params: { webhookId: string, apiKey: string }): Promise<any> {
     const apiBaseUrl = this.configService.get('CHARGE_BASE_URL')
     const url = `${apiBaseUrl}/api/v0/notifications/webhook/addresses/${params.webhookId}?apiKey=${params.apiKey}`
-    await this.httpProxyGet(url)
+    return await this.httpProxyGet(url)
   }
 
   async httpProxyPost (url: string, requestBody: any) {


### PR DESCRIPTION
## Proposed changes

Fix getWebhookAddresses not returning.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
