### PR TITLE
fix: Helm & Docker - Code updates

### DIFF
--- a/amplitude/proxy/Dockerfile
+++ b/amplitude/proxy/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:1.25.4-alpine
 
 RUN apk upgrade --update-cache --available
 
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf.example /etc/nginx/nginx.conf
 
 STOPSIGNAL SIGTERM
 

--- a/amplitude/proxy/docker-compose.yaml
+++ b/amplitude/proxy/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: "3.9"
+
+services:
+  amplitude:
+    build:
+      context: .
+    hostname: amplitude
+    container_name: amplitude
+    network_mode: bridge
+    restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "25"
+        compress: "true"
+    ulimits:
+      nofile:
+        soft: 1000000
+        hard: 1000000
+    ports:
+      - "8888:8888"

--- a/amplitude/proxy/nginx.conf.example
+++ b/amplitude/proxy/nginx.conf.example
@@ -4,7 +4,6 @@ events {
     worker_connections 1024;
 }
 
-
 http {
     include mime.types;
     default_type application/octet-stream;

--- a/k8s/helm/charts/amplitude/templates/configmap.yaml
+++ b/k8s/helm/charts/amplitude/templates/configmap.yaml
@@ -37,13 +37,16 @@ data:
       error_log /var/log/nginx/error.log info;
 
       # Timeouts
-      keepalive_timeout 65s;
+      keepalive_timeout 0;
 
       # Server
       server {
         listen 8888 deferred default_server;
 
         location /amplitude {
+          add_header 'Access-Control-Allow-Origin' '*';
+          add_header 'Access-Control-Allow-Methods' 'GET, POST';
+
           proxy_pass https://api2.amplitude.com/2/httpapi;
         }
 


### PR DESCRIPTION
## Proposed changes

Amplitude Nginx proxy doesn't have CORS headers to allow requests from other domains. Added it for all domains for GET and POST requests.

Summary:

- Added Compose file for Amplitude proxy local testing;
- Updated Dockerfile & nginx.conf.example;
- Updated Amplitude proxy ConfigMap (nginx.conf).

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
