### PR TITLE
Add option to filter ERC20 token balances by specific token address

### DIFF
--- a/apps/charge-api-service/src/balances-api/balances-api.controller.ts
+++ b/apps/charge-api-service/src/balances-api/balances-api.controller.ts
@@ -18,9 +18,13 @@ export class BalancesAPIController {
   })
   @ApiQuery({ name: 'apiKey', type: String, required: true, description: 'Your API key to authenticate requests.' })
   @ApiParam({ name: 'address', type: String, required: true, description: 'The wallet address to query for ERC20 token balances.' })
+  @ApiQuery({ name: 'tokenAddress', type: String, required: false, description: 'Optional. Filter results by a specific token address.' })
   @ApiForbiddenResponse({ description: 'Access to the resource is forbidden.' })
-  getERC20TokenBalances (@Param('address') address: string) {
-    return this.balancesAPIService.getERC20TokenBalances(address)
+  getERC20TokenBalances (
+    @Param('address') address: string,
+    @Query('tokenAddress') tokenAddress?: string
+  ) {
+    return this.balancesAPIService.getERC20TokenBalances(address, tokenAddress)
   }
 
   @Get('nft-assets/:address')

--- a/apps/charge-api-service/src/balances-api/balances-api.service.ts
+++ b/apps/charge-api-service/src/balances-api/balances-api.service.ts
@@ -9,8 +9,8 @@ export class BalancesAPIService {
     @Inject(networkService) private readonly networkClient: ClientProxy
   ) { }
 
-  async getERC20TokenBalances (address: string): Promise<any> {
-    return callMSFunction(this.networkClient, 'get_erc20_token_balances', address)
+  async getERC20TokenBalances (address: string, tokenAddress?: string): Promise<any> {
+    return callMSFunction(this.networkClient, 'get_erc20_token_balances', { address, tokenAddress })
   }
 
   async getERC721TokenBalances (address: string, limit: number = 100, cursor?: string): Promise<any> {

--- a/apps/charge-api-service/src/balances-api/docs/fuse-balances-api.yml
+++ b/apps/charge-api-service/src/balances-api/docs/fuse-balances-api.yml
@@ -69,6 +69,12 @@ paths:
           schema:
             type: string
           description: The wallet address to query for ERC20 tokens.
+        - name: tokenAddress
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional. The specific token address to query. If not provided, all token balances will be returned.
       responses:
         "200":
           description: OK

--- a/apps/charge-network-service/src/balances/balances.controller.ts
+++ b/apps/charge-network-service/src/balances/balances.controller.ts
@@ -9,8 +9,8 @@ export class BalancesController {
   ) { }
 
   @MessagePattern('get_erc20_token_balances')
-  getERC20TokenBalances (address: string) {
-    return this.balancesService.getERC20TokenBalances(address)
+  getERC20TokenBalances (data: { address: string; tokenAddress?: string }) {
+    return this.balancesService.getERC20TokenBalances(data.address, data.tokenAddress)
   }
 
   @MessagePattern('get_erc721_token_balances')

--- a/apps/charge-network-service/src/balances/balances.service.ts
+++ b/apps/charge-network-service/src/balances/balances.service.ts
@@ -3,6 +3,9 @@ import { ConfigService } from '@nestjs/config'
 import { UnmarshalService } from 'apps/charge-network-service/src/balances/services/unmarshal-balance.service'
 import { ExplorerService } from 'apps/charge-network-service/src/balances/services/explorer-balance.service'
 import { BalanceService } from 'apps/charge-network-service/src/balances/interfaces/balances.interface'
+import { BaseProvider, Contract, EthersContract, InjectContractProvider, InjectEthersProvider } from 'nestjs-ethers'
+import BasicTokenAbi from '@app/smart-wallets-service/common/config/abi/BasicToken.json'
+import { NATIVE_FUSE_TOKEN } from '@app/smart-wallets-service/common/constants/fuseTokenInfo'
 
 @Injectable()
 export default class BalancesService {
@@ -11,7 +14,11 @@ export default class BalancesService {
   constructor (
     private readonly configService: ConfigService,
     private readonly unmarshalService: UnmarshalService,
-    private readonly explorerService: ExplorerService
+    private readonly explorerService: ExplorerService,
+    @InjectEthersProvider('regular-node')
+    private readonly rpcProvider: BaseProvider,
+    @InjectContractProvider('regular-node')
+    private readonly ethersContract: EthersContract
   ) {}
 
   private get primaryService (): BalanceService {
@@ -24,7 +31,67 @@ export default class BalancesService {
     return primaryService === 'explorer' ? this.unmarshalService : this.explorerService
   }
 
-  async getERC20TokenBalances (address: string) {
+  private async getTokenInfo (address: string, tokenAddress?: string) {
+    const isNativeToken = !tokenAddress || tokenAddress.toLowerCase() === NATIVE_FUSE_TOKEN.address.toLowerCase()
+    const tokenInfo = isNativeToken ? await this.getNativeTokenInfo(address) : await this.getERC20TokenInfo(address, tokenAddress)
+
+    return tokenInfo.balance === '0' ? null : tokenInfo
+  }
+
+  private async getNativeTokenInfo (address: string) {
+    const balance = (await this.rpcProvider.getBalance(address)).toString()
+    return {
+      balance,
+      contractAddress: NATIVE_FUSE_TOKEN.address.toLowerCase(),
+      decimals: '18',
+      name: 'Fuse',
+      symbol: 'FUSE',
+      type: 'native' as const
+    }
+  }
+
+  private async getERC20TokenInfo (address: string, tokenAddress: string) {
+    const contract: Contract = this.ethersContract.create(tokenAddress, BasicTokenAbi)
+    const [balance, decimals, name, symbol] = await Promise.all([
+      contract.balanceOf(address),
+      contract.decimals(),
+      contract.name(),
+      contract.symbol()
+    ])
+
+    return {
+      balance: balance.toString(),
+      contractAddress: tokenAddress.toLowerCase(),
+      decimals,
+      name,
+      symbol,
+      type: 'ERC-20' as const
+    }
+  }
+
+  async getERC20TokenBalances (address: string, tokenAddress?: string) {
+    if (tokenAddress) {
+      return this.getSingleTokenBalance(address, tokenAddress.toLowerCase())
+    }
+
+    return this.getMultipleTokenBalances(address)
+  }
+
+  private async getSingleTokenBalance (address: string, tokenAddress: string) {
+    try {
+      const tokenInfo = await this.getTokenInfo(address, tokenAddress)
+      return {
+        message: 'OK',
+        result: tokenInfo ? [tokenInfo] : [],
+        status: '1'
+      }
+    } catch (error) {
+      this.logger.error(`Error fetching token balance: ${error.message}`, error.stack)
+      return { message: 'OK', result: [], status: '0' }
+    }
+  }
+
+  private async getMultipleTokenBalances (address: string) {
     try {
       return await this.primaryService.getERC20TokenBalances(address)
     } catch (error) {

--- a/apps/charge-network-service/src/balances/services/explorer-balance.service.ts
+++ b/apps/charge-network-service/src/balances/services/explorer-balance.service.ts
@@ -6,6 +6,7 @@ import { BalanceService } from '../interfaces/balances.interface'
 import GraphQLService from '@app/common/services/graphql.service'
 import { getCollectiblesByOwner } from '@app/network-service/common/constants/graph-queries/nfts'
 import { ethers } from 'ethers'
+import { NATIVE_FUSE_TOKEN } from '@app/smart-wallets-service/common/constants/fuseTokenInfo'
 
 @Injectable()
 export class ExplorerService implements BalanceService {
@@ -43,7 +44,7 @@ export class ExplorerService implements BalanceService {
     return [
       {
         balance: balance.toString(),
-        contractAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        contractAddress: NATIVE_FUSE_TOKEN.address.toLowerCase(),
         decimals: '18',
         name: 'Fuse',
         symbol: 'FUSE',


### PR DESCRIPTION
## Proposed changes

This PR introduces the ability to filter ERC20 token balances by a specific token address. Key changes include:
- Updated the BalancesController to accept an optional tokenAddress parameter.
- Modified the BalancesService to handle single token balance requests.
- Implemented new methods in BalancesService for fetching single and multiple token balances.
- Updated the getERC20TokenBalances method to use the new filtering functionality.
- Added error handling and logging for token balance fetching.
- These changes improve the flexibility of the API, allowing users to query balances for specific tokens efficiently.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Refactor or a modification (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
