### PR TITLE
fix: Disable amplitude-proxy on Google Cloud

### DIFF
--- a/k8s/helm/production.yaml
+++ b/k8s/helm/production.yaml
@@ -85,7 +85,7 @@ accounts:
     - cron_job_secret
 
 amplitude:
-  enabled: true
+  enabled: false # amplitude-proxy was migrated to OVH Cloud
 
   # Replicas
   replicas: 2


### PR DESCRIPTION
## Description

I'm continuing on OVH Cloud migration process. Endpoint https://analytics.fuse.io was migrated to OVH Cloud and should be disabled on Google Cloud to save costs.

Summary:

- Disable amplitude-proxy on Google Cloud.

## Type of change

 Please delete options that are not relevant.

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update


# How Has This Been Tested?

 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

 - [x] Test A - Run the code locally;
 - [x] Test B - Run the code on `qa` environment (if exists);
 - [x] Test C - ...

## Notes

 If you want to left some extra comment please type it here.
