### PR TITLE
fix: Improve error handling in BundlerApiInterceptor and PaymasterApiService

### DIFF
--- a/apps/charge-api-service/src/paymaster-api/paymaster-api.service.ts
+++ b/apps/charge-api-service/src/paymaster-api/paymaster-api.service.ts
@@ -157,10 +157,16 @@ export class PaymasterApiService {
         )
         .pipe(
           catchError((e) => {
+            // Log specific error types for better debugging
+            if (e?.response?.status === 503 || e?.response?.status === 502) {
+              this.logger.error(`Service unavailable error (${e?.response?.status}): RPC node may be down`)
+            }
+
             const errorReason =
+              e?.response?.data?.error?.message ||
               e?.result?.error ||
-              e?.result?.error?.message ||
-              ''
+              e?.message ||
+              'Unknown error during gas estimation'
 
             this.logger.error(`RpcException catchError: ${errorReason} ${JSON.stringify(e)}`)
             throw new RpcException(errorReason)


### PR DESCRIPTION
## Description

- Enhanced logging for JSON-RPC errors in BundlerApiInterceptor, including specific messages for validation failures and CALL_EXCEPTION errors.
- Updated error handling in PaymasterApiService to log service unavailability errors (502, 503) for better debugging.

## Type of change

 Please delete options that are not relevant.

 - [x] Bug fix (non-breaking change which fixes an issue)